### PR TITLE
Aadejare Patch 2 

### DIFF
--- a/tournamentSchema.json
+++ b/tournamentSchema.json
@@ -23,7 +23,7 @@
     },
     "version": {
       "type": "string",
-      "enum": [ "v0.1", "v0.2", "v1.0" ],
+      "enum": [ "v0.1", "v0.2", "v1.0", "v1.1"],
       "description": "Stores the version of the Open Bracket Format specification that this file was generated in accordance with. It is highly recommended (but not required) to include this field -- if this field is not set, the default assumption will be that the file was generated with the most recent version of OBF. The current version of the OBF format (what you are reading) is `v0.2`."
     }
   },
@@ -131,9 +131,21 @@
           "type": "string",
           "description": "String containing entrant's legal name."
         },
+		"genders": {
+          "type": "array",
+          "description": "Array containing entrant's gender(s)."
+        },
         "country": {
           "type": "string",
           "description": "String containing entrant's country."
+        },
+        "languages": {
+          "type": "array",
+          "description": "An array of string containing entrant's language(s) to communicate from most to least frequently used."
+        },      
+        "pronouns": {
+          "type": "array",
+          "description": "Array containing entrant's pronouns for identification"
         },
         "tag": {
           "type": "string",


### PR DESCRIPTION
Update and refactored schema to 1.0 schema on my brach to reconcile my edits with 1.0 schema that was adopted  Made the following changes to Personal Information  gender -> genders (string -> array)
language [and mainLanguage] -> languages (string -> array) pronouns (string -> array)
entrantTeam (removed minLength as it is a boolean)  Added 1.1 as a version type